### PR TITLE
Set git default branch to main

### DIFF
--- a/roles/git/templates/gitconfig.j2
+++ b/roles/git/templates/gitconfig.j2
@@ -1,3 +1,5 @@
+[init]
+  defaultBranch = main
 [user]
   name = {{ git_user_name }}
   email = {{ git_user_email }}


### PR DESCRIPTION
To avoid this warning after each `git init`

![CleanShot 2022-09-22 at 15 05 39](https://user-images.githubusercontent.com/523981/191754825-70c297b6-cdcc-402e-8afd-db5cff23454a.png)
