### PR TITLE
Fix xdebug install for php < 8.0

### DIFF
--- a/roles/php/tasks/install_php.yml
+++ b/roles/php/tasks/install_php.yml
@@ -26,7 +26,7 @@
   with_items: "{{ php_extensions }}"
 
 - name: "{{ php_current_version }} - Install xdebug"
-  shell: "{{ pecl_bin }} install {{ xdebug_package }}"
+  shell: "{{ pecl_bin }} install {{ (php_current_version >= 8)| ternary(xdebug_package, xdebug_package_for_php_7) }}"
   register: pecl_result
   changed_when: "pecl_result.rc == 0"
   failed_when: "not (('already installed' in pecl_result.stdout) or ('install ok:' in pecl_result.stdout))"

--- a/roles/php/vars/main.yml
+++ b/roles/php/vars/main.yml
@@ -1,5 +1,6 @@
 ---
 php_custom_config_file: /usr/local/etc/php/{{ php_current_version }}/conf.d/custom.ini
 xdebug_package: "xdebug"
+xdebug_package_for_php_7: "xdebug-3.1.6"
 
 php_homebrew_tap: "shivammathur/php"


### PR DESCRIPTION
Xdebug 3.2 only works with PHP 8, see https://xdebug.org/docs/compat