### PR TITLE
Configure drupal config for nginx

### DIFF
--- a/roles/nginx/templates/conf/drupal.j2
+++ b/roles/nginx/templates/conf/drupal.j2
@@ -80,6 +80,8 @@ location ~ '\.php$|^/update.php' {
     fastcgi_param PATH_INFO $fastcgi_path_info;
     fastcgi_param QUERY_STRING $query_string;
     fastcgi_intercept_errors on;
+    fastcgi_buffer_size 512k;
+    fastcgi_buffers 16 512k;
     fastcgi_pass 127.0.0.1:{{ site_php_fpm_port }};
 }
 


### PR DESCRIPTION
Fix `upstream sent too big header while reading response header from upstream`