### PR TITLE
Add role to use logrotate for php-fpm log

### DIFF
--- a/playbooks/setup.yml
+++ b/playbooks/setup.yml
@@ -63,6 +63,8 @@
       tags: minio
     - role: redis
       tags: redis
+    - role: logrotate
+      tags: logrotate
     - upgrade
     - role: cleanup
       tags: cleanup

--- a/roles/logrotate/handlers/main.yml
+++ b/roles/logrotate/handlers/main.yml
@@ -1,0 +1,4 @@
+---
+
+- name: Restart logrotate
+  command: brew services restart logrotate

--- a/roles/logrotate/tasks/main.yml
+++ b/roles/logrotate/tasks/main.yml
@@ -1,0 +1,17 @@
+---
+
+- name: Install logrotate
+  homebrew:
+    name: logrotate
+    state: "{{ homebrew_package_state }}"
+
+- name: Create logrotate config directory
+  file:
+    path: '{{ logrotate_config_directory }}'
+    state: directory
+
+- name: Add logrotate php-fpm config
+  template:
+    src: php-fpm.j2
+    dest: "{{ logrotate_config_directory }}/php-fpm.conf"
+  notify: Restart logrotate

--- a/roles/logrotate/templates/php-fpm.j2
+++ b/roles/logrotate/templates/php-fpm.j2
@@ -1,0 +1,9 @@
+{{ ansible_managed | comment }}
+
+{{ brew_prefix }}/var/log/php-fpm.log {
+    daily
+    rotate 7
+    compress
+    missingok
+    notifempty
+}

--- a/roles/logrotate/vars/main.yml
+++ b/roles/logrotate/vars/main.yml
@@ -1,0 +1,3 @@
+---
+
+logrotate_config_directory: "{{ brew_prefix }}/etc/logrotate.d"


### PR DESCRIPTION
Fix #190.

Maybe daily is to much but honestly I don't think we need to keep many months of logs.

Result after one day: 

php-fpm.log
php-fpm.log-20240130.gz => 287M (was 5.8G 😅 before compression)

We could also configure logrotate on nginx logs. 
On my laptop, `error.log` use 1.2G and some website access logs are bigger than 200M.