### PR TITLE
Allow to configure ansible version when bootstrap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,11 @@ tags: ## List all tags
 
 .PHONY: bootstrap
 bootstrap: ## Bootstrap the dev environment for the first time
-	@scripts/bootstrap.sh
+	@scripts/bootstrap.sh "$(ansible_version_spec)"
+
+.PHONY: install-ansible
+install-ansible: ## Install ansible, you can install a specific version with: ansible_version_spec=<2.18
+	@scripts/install-ansible.sh "$(ansible_version_spec)"
 
 .PHONY: setup
 setup: ## Setup the dev environment

--- a/Makefile
+++ b/Makefile
@@ -41,10 +41,6 @@ upgrade: ## Upgrade of the apps and dev environment
 	@echo ""
 	@brew cu -y --cleanup
 	@echo ""
-	@echo "Upgrade ansible"
-	@echo ""
-	@pipx upgrade --include-injected ansible
-	@echo ""
 	@echo "Upgrade of the dev environment"
 	@echo ""
 	@$(ANSIBLE_PLAYBOOK_SETUP) --extra-vars='upgrade_all_packages=true' --tags=$(tags)

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Then :
 
 ```shell
 # Edit your bashrc or zshrc to include "export PIPX_HOME=$HOME/.local/pipx"
+# To bootstrap with a specific Ansible version: make bootstrap ansible_version_spec="<2.18"
 $ make bootstrap
 $ make setup-mkcert
 ```

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -17,8 +17,7 @@ brew update
 
 echo "Installing Ansible..."
 brew install python pipx
-pipx install --include-deps ansible
-pipx inject ansible passlib
+$(dirname "$0")/install-ansible.sh $1
 
 echo "Provisioning with Ansible..."
 make setup

--- a/scripts/install-ansible.sh
+++ b/scripts/install-ansible.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 
-pipx install ansible-core
-pipx inject ansible-core ansible
-pipx inject ansible-core passlib
-pipx inject ansible-core github3-py
+pipx install ansible-core --force
+pipx inject ansible-core ansible --force
+pipx inject ansible-core passlib --force
+pipx inject ansible-core github3-py --force
 
 if [ -n "$1" ]; then
   echo "Force install of ansible-core$1"

--- a/scripts/install-ansible.sh
+++ b/scripts/install-ansible.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+pipx install ansible-core
+pipx inject ansible-core ansible
+pipx inject ansible-core passlib
+pipx inject ansible-core github3-py
+
+if [ -n "$1" ]; then
+  echo "Force install of ansible-core$1"
+  pipx inject ansible-core "ansible-core$1" --force
+fi


### PR DESCRIPTION
We need to use ansible < 2.18 because of OVH shared hosting (old version of Python).

We can now specify an ansible version when we bootstrap.

You need to reset you ansible install : 

```
$ pipx uninstall ansible
$ pipx uninstall ansible-core
$ dev install-ansible ansible_version_spec="<2.18"
```