### PR TITLE
Remove homebrew base packages already installed during bootstrap

### DIFF
--- a/roles/common/vars/main.yml
+++ b/roles/common/vars/main.yml
@@ -7,7 +7,6 @@ homebrew_tap:
   - akollade/tap
 
 homebrew_base_packages:
-  - openssl
   - curl
   - coreutils
   - pwgen
@@ -15,8 +14,6 @@ homebrew_base_packages:
   - tree
   - grep
   - httpie
-  - python
-  - pipx
   - zsh
   - tmux
   - gs # pdf


### PR DESCRIPTION
This packages are now installed in `bootstrap.sh` before setup.

This will fix the following warnings: 

```
Warning: python@3.13 3.13.1 is already installed and up-to-date.
    To reinstall 3.13.1, run:
      brew reinstall python@3.13
    Warning: openssl@3 3.4.0 is already installed and up-to-date.
    To reinstall 3.4.0, run:
      brew reinstall openssl@3
```