### PR TITLE
Remove disabled packages and deprecated taps

### DIFF
--- a/roles/common/vars/main.yml
+++ b/roles/common/vars/main.yml
@@ -2,7 +2,6 @@
 homebrew_tap:
   - homebrew/services
   - buo/cask-upgrade
-  - akollade/tap
 
 homebrew_base_packages:
   - curl

--- a/roles/common/vars/main.yml
+++ b/roles/common/vars/main.yml
@@ -2,8 +2,6 @@
 homebrew_tap:
   - homebrew/services
   - buo/cask-upgrade
-  - homebrew/cask-fonts
-  - homebrew/cask-versions
   - akollade/tap
 
 homebrew_base_packages:

--- a/roles/common/vars/main.yml
+++ b/roles/common/vars/main.yml
@@ -25,7 +25,6 @@ homebrew_base_packages:
   - telnet
   - mas
   - wget
-  - ruby@2.7
   - vips # https://github.com/lovell/sharp/issues/1593#issuecomment-475680243
   - gnu-tar
   - gsed


### PR DESCRIPTION
Fix the following errors : 

### ruby@2.7 is disabled

```
Error: ruby@2.7 has been disabled because it is not supported upstream! It was disabled on 2024-06-15.
```

### homebrew/cask-fonts and homebrew/cask-versions are deprecated

```
failed: [127.0.0.1] (item=homebrew/cask-fonts) => changed=false 
  ansible_loop_var: item
  item: homebrew/cask-fonts
  msg: |-
    added: 0, unchanged: 0, error: failed to tap: homebrew/cask-fonts due to Error: homebrew/cask-fonts was deprecated. This tap is now empty and all its contents were either deleted or migrated.
failed: [127.0.0.1] (item=homebrew/cask-versions) => changed=false 
  ansible_loop_var: item
  item: homebrew/cask-versions
  msg: |-
    added: 0, unchanged: 0, error: failed to tap: homebrew/cask-versions due to Error: homebrew/cask-versions was deprecated. This tap is now empty and all its contents were either deleted or migrated.
```

We can now directly install font patched for powerline using cask, for example: https://formulae.brew.sh/cask/font-source-code-pro-for-powerline. But should we provide one by default?